### PR TITLE
Add Model.flag_for_column and Model.column_for_flag scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ Profile.languages.pairs                     #=> {"English"=>:english, "Spanish"=
 
 # Scope methods
 Profile.where_languages(:french, :spanish)  #=> SELECT * FROM profiles WHERE languages & 10 > 0
+
 Profile.languages.set_all!(:chinese)        #=> UPDATE "profiles" SET languages = COALESCE(languages, 0) | 4
 Profile.languages.unset_all!(:chinese)      #=> UPDATE "profiles" SET languages = COALESCE(languages, 0) & ~4
+
+Profile.flag_for_languages(:chinese)        #=> 4
+Profile.languages_for_flag(4)               #=> #<ActiveFlag::Value: {:chinese}>
 ```
 
 ## Install
@@ -64,7 +68,9 @@ add_column :users, :languages, :integer, null: false, default: 0, limit: 8
 
 `limit: 8` is only required if you need more than 32 flags.
 
-## Query
+## Scopes
+
+### where_[column] scope
 
 For a querying purpose, use `where_[column]` scope.
 
@@ -84,6 +90,28 @@ If you want to change it to `and` operation, you can specify:
 
 ```ruby
 Profile.where_languages(:french, :spanish, op: :and) #=> SELECT * FROM profiles WHERE languages = 10
+```
+
+### flag_for_[column] scope
+
+To find out which bit the flags correspond to, use the method:
+```ruby
+Profile.flag_for_languages                     #=> 0
+Profile.flag_for_languages(:fake)              #=> 0
+Profile.flag_for_languages(:spanish)           #=> 2
+Profile.flag_for_languages(:spanish, :spanish) #=> 2
+Profile.flag_for_languages(:chinese)           #=> 4
+Profile.flag_for_languages(:spanish, :chinese) #=> 6
+Profile.flag_for_languages(:chinese, :spanish) #=> 6
+```
+
+### [column]_for_flag scope
+
+To find out which bit matches your flags, use the method:
+```ruby
+Profile.languages_for_flag(2) #=> #<ActiveFlag::Value: {:spanish}>
+Profile.languages_for_flag(4) #=> #<ActiveFlag::Value: {:chinese}>
+Profile.languages_for_flag(6) #=> #<ActiveFlag::Value: {:spanish, :chinese}>
 ```
 
 ## Translation

--- a/lib/active_flag.rb
+++ b/lib/active_flag.rb
@@ -33,7 +33,7 @@ module ActiveFlag
         active_flags[column]
       end
 
-      # Scopes
+      # Scope where_column
       define_singleton_method "where_#{column}" do |*args|
         options = args.extract_options!
         integer = active_flags[column].to_i(args)
@@ -43,6 +43,16 @@ module ActiveFlag
         else
           where("#{column_name} & #{integer} > 0")
         end
+      end
+
+      # Scope flag_for_column
+      define_singleton_method "flag_for_#{column}" do |*args|
+        active_flags[column].to_i(args)
+      end
+
+      # Scope column_for_flag
+      define_singleton_method "#{column}_for_flag" do |entry|
+        active_flags[column].to_value(self, entry)
       end
     end
   end

--- a/test/active_flag_test.rb
+++ b/test/active_flag_test.rb
@@ -114,10 +114,28 @@ class ActiveFlagTest < Minitest::Test
     assert_equal Other.others.keys, [:another]
   end
 
-  def test_scope
+  def test_where_column
     assert_equal Profile.where_languages(:english).count, 2
     assert_equal Profile.where_languages(:japanese).count, 2
     assert_equal Profile.where_languages(:english, :japanese).count, 3
     assert_equal Profile.where_languages(:english, :japanese, op: :and).count, 1
+  end
+
+  def test_flag_for_column
+    assert_equal Profile.flag_for_languages, 0
+    assert_equal Profile.flag_for_languages(nil), 0
+    assert_equal Profile.flag_for_languages(:fake), 0
+    assert_equal Profile.flag_for_languages(:spanish), 2
+    assert_equal Profile.flag_for_languages(:spanish, :spanish), 2
+    assert_equal Profile.flag_for_languages(:chinese), 4
+  end
+
+  def test_column_for_flag
+    assert_equal Profile.languages_for_flag(0), ActiveFlag::Value.new
+    assert_equal Profile.languages_for_flag(0), ActiveFlag::Value.new(nil)
+    assert_equal Profile.languages_for_flag(2), ActiveFlag::Value.new([:spanish])
+    refute_equal Profile.languages_for_flag(4), ActiveFlag::Value.new([:spanish, :spanish])
+    assert_equal Profile.languages_for_flag(4), ActiveFlag::Value.new([:chinese])
+    assert_equal Profile.languages_for_flag(6), ActiveFlag::Value.new([:spanish, :chinese])
   end
 end


### PR DESCRIPTION

### flag_for_[column] scope

To find out which bit the flags correspond to, use the method:
```ruby
Profile.flag_for_languages                     #=> 0
Profile.flag_for_languages(:fake)              #=> 0
Profile.flag_for_languages(:spanish)           #=> 2
Profile.flag_for_languages(:spanish, :spanish) #=> 2
Profile.flag_for_languages(:chinese)           #=> 4
```

### [column]_for_flag scope
To find out which bit matches your flags, use the method:
```ruby
Profile.languages_for_flag(2) #=> #<ActiveFlag::Value: {:spanish}>
Profile.languages_for_flag(4) #=> #<ActiveFlag::Value: {:chinese}>
Profile.languages_for_flag(6) #=> #<ActiveFlag::Value: {:spanish, :chinese}>
```