### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.5.3
-before_install: gem install bundler -v 1.13.6
+  - 2.5
+  - 2.6
+  - 2.7
+before_install: gem install bundler -v 1.16.2
 gemfile:
+  - gemfiles/5.0.gemfile
+  - gemfiles/5.1.gemfile
   - gemfiles/5.2.gemfile
   - gemfiles/6.0.gemfile

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 5.0"
+
+group :development, :test do
+  gem "bundler"
+  gem "rake"
+  gem "minitest"
+  gem "sqlite3"
+end
+
+gemspec :path => "../"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 5.1"
+
+group :development, :test do
+  gem "bundler"
+  gem "rake"
+  gem "minitest"
+  gem "sqlite3"
+end
+
+gemspec :path => "../"


### PR DESCRIPTION
Added more versions of ruby and rails.

Remove the no-longer-used Travis setting `sudo: false`. [link](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)