### PR TITLE
Avoid using the last argument as keyword parameters for Ruby 3.0 support

### DIFF
--- a/lib/active_flag/definition.rb
+++ b/lib/active_flag/definition.rb
@@ -59,7 +59,7 @@ module ActiveFlag
       defaults << :"active_flag.#{@column}.#{key}"
       defaults << options.delete(:default) if options[:default]
       defaults << key.to_s.humanize
-      I18n.translate defaults.shift, options.reverse_merge(count: 1, default: defaults)
+      I18n.translate defaults.shift, **options.reverse_merge(count: 1, default: defaults)
     end
   end
 end

--- a/lib/active_flag/value.rb
+++ b/lib/active_flag/value.rb
@@ -29,12 +29,12 @@ module ActiveFlag
 
     def set!(key, options={})
       set(key)
-      @instance.save!(options)
+      @instance.save!(**options)
     end
 
     def unset!(key, options={})
       unset(key)
-      @instance.save!(options)
+      @instance.save!(**options)
     end
 
     def set?(key)


### PR DESCRIPTION
This PR resolves the following deprecation warnings when using active_flag with Ruby 2.7:

```
lib/active_flag/value.rb:32: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
lib/active_flag/value.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
lib/active_flag/definition.rb:62: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```