### PR TITLE
'require' is needed

### DIFF
--- a/lib/active_flag/value.rb
+++ b/lib/active_flag/value.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module ActiveFlag
   class Value < Set
     def with(instance, definition)


### PR DESCRIPTION
`rake test` has failed.

```
$ ruby -v
ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [arm64-darwin21]
$ bundle exec rake test
Traceback (most recent call last):
        11: from /Users/komagata/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
        10: from /Users/komagata/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
         9: from /Users/komagata/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
         8: from /Users/komagata/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
         7: from /Users/komagata/go/src/github.com/komagata/active_flag/test/active_flag_test.rb:1:in `<top (required)>'
         6: from /Users/komagata/go/src/github.com/komagata/active_flag/test/active_flag_test.rb:1:in `require'
         5: from /Users/komagata/go/src/github.com/komagata/active_flag/test/test_helper.rb:1:in `<top (required)>'
         4: from /Users/komagata/go/src/github.com/komagata/active_flag/test/test_helper.rb:1:in `require'
         3: from /Users/komagata/go/src/github.com/komagata/active_flag/lib/active_flag.rb:3:in `<top (required)>'
         2: from /Users/komagata/go/src/github.com/komagata/active_flag/lib/active_flag.rb:3:in `require'
         1: from /Users/komagata/go/src/github.com/komagata/active_flag/lib/active_flag/value.rb:1:in `<top (required)>'
/Users/komagata/go/src/github.com/komagata/active_flag/lib/active_flag/value.rb:2:in `<module:ActiveFlag>': uninitialized constant ActiveFlag::Set (NameError)
rake aborted!
Command failed with status (1)
/Users/komagata/.rbenv/versions/2.7.5/bin/bundle:25:in `load'
/Users/komagata/.rbenv/versions/2.7.5/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

After this PR.

```
$ rake test
Run options: --seed 42457

# Running:

..................

Fabulous run in 0.012554s, 1433.8060 runs/s, 3026.9237 assertions/s.

18 runs, 38 assertions, 0 failures, 0 errors, 0 skips
```