### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: ci
+on: [pull_request, push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - ruby-head
+        rails_version:
+          - "7.0"
+          - "6.1"
+          - "6.0"
+          - "5.2"
+        exclude:
+          - ruby: "2.6"
+            rails_version: "7.0"
+          - ruby: "3.0"
+            rails_version: "5.2"
+          - ruby: "3.1"
+            rails_version: "5.2"
+          - ruby: "3.1"
+            rails_version: "6.0"
+          - ruby: ruby-head
+            rails_version: "5.2"
+          - ruby: ruby-head
+            rails_version: "6.0"
+          - ruby: ruby-head
+            rails_version: "6.1"
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.rails_version }}.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler: ${{ matrix.bundler }}
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec rake

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0"
+gem "activerecord", "~> 5.0.0"
 
 group :development, :test do
   gem "bundler"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1"
+gem "activerecord", "~> 5.1.1"
 
 group :development, :test do
   gem "bundler"

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6"
+gem "activerecord", "~> 6.0.0"
 
 group :development, :test do
   gem "bundler"

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
+gem "activerecord", "~> 6.1.0"
 
 group :development, :test do
   gem "bundler"

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
+gem "activerecord", "~> 7.0.0"
 
 group :development, :test do
   gem "bundler"


### PR DESCRIPTION
This PR sets up CI on GitHub Actions, as Travis CI.org is no longer active.  It all runs green on my fork.