### PR TITLE
allow initialization with Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ If you need to work with huge bit arrays, take a look at [Bitwise](https://githu
 ```ruby
 class Profile < ActiveRecord::Base
   flag :languages, [:english, :spanish, :chinese, :french, :japanese]
+  # {:english=>1, :spanish=>2, :chinese=>4, :french=>8, :japanese=>16 }
+  # OR you can specify values explicitly for future safety & convinience
+  flag :languages, { english: 1, spanish: 2, chinese: 4, french: 8, japanese: 16 }
 end
-
-# {:english=>1, :spanish=>2, :chinese=>4, :french=>8, :japanese=>16 }
 
 # Instance methods
 profile.languages                           #=> #<ActiveFlag::Value: {:english, :japanese}>

--- a/lib/active_flag/definition.rb
+++ b/lib/active_flag/definition.rb
@@ -57,7 +57,7 @@ module ActiveFlag
     end
 
     def to_value(instance, integer)
-      Value.new(to_array(integer)).with(instance, self)
+      Value.new(to_array(integer), instance, self)
     end
 
     def to_array(integer)

--- a/lib/active_flag/definition.rb
+++ b/lib/active_flag/definition.rb
@@ -4,8 +4,26 @@ module ActiveFlag
 
     def initialize(column, keys, klass)
       @column = column
-      @keys = keys.freeze
-      @maps = Hash[keys.map.with_index{ |key, i| [key, 2**i] }].freeze
+      keys = keys.dup
+      if keys.is_a?(Hash)
+        keys.symbolize_keys!
+        if invalid = keys.values.find{|i| !i.is_a?(Integer) || (i & i-1) > 0 }
+          raise [invalid, " is not an Integer with a base of 2"].join
+        end
+        unless keys.values.size == keys.values.uniq.size
+          raise "duplicate values detected"
+        end
+
+        @keys = keys.keys.freeze
+        @maps = keys.freeze
+      else
+        keys = keys.map(&:to_sym)
+        unless keys.size == keys.uniq.size
+          raise "duplicate keys detected"
+        end
+        @keys = keys.freeze
+        @maps = Hash[keys.map.with_index{ |key, i| [key, 2**i] }].freeze
+      end
       @klass = klass
     end
 

--- a/lib/active_flag/value.rb
+++ b/lib/active_flag/value.rb
@@ -2,11 +2,15 @@ require 'set'
 
 module ActiveFlag
   class Value < Set
-    def with(instance, definition)
+    def initialize(values, instance, definition)
+      super(values)
       @instance = instance
       @definition = definition
       @column = definition.column
-      return self
+
+      @definition.keys.each do |key|
+        define_singleton_method( [key, '?'].join ) { set?( key.to_sym ) }
+      end
     end
 
     def raw
@@ -45,14 +49,6 @@ module ActiveFlag
 
     def unset?(key)
       !set?(key)
-    end
-
-    def method_missing(symbol, *args, &block)
-      if key = symbol.to_s.chomp!('?') and @definition.keys.include?(key.to_sym)
-        set?(key.to_sym)
-      else
-        super
-      end
     end
   end
 end

--- a/lib/active_flag/version.rb
+++ b/lib/active_flag/version.rb
@@ -1,3 +1,3 @@
 module ActiveFlag
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end

--- a/lib/active_flag/version.rb
+++ b/lib/active_flag/version.rb
@@ -1,3 +1,3 @@
 module ActiveFlag
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
@kenn thank you for this beautiful and elegant gem!
I've added an ability to initialize it with Hash.
It is a safer & better option:
- you won't be able to accidentally break everything by deleting or moving one of the keys
- you can specify keys in any order and use any integer values (as long as they have a base of 2)
- you can safely remove any keys in case you don't need them or don't want their methods to be available

Also, added a validation for duplicate keys when initializing with an Array.