### PR TITLE
Add support to initialize definition with strings

### DIFF
--- a/lib/active_flag.rb
+++ b/lib/active_flag.rb
@@ -16,7 +16,7 @@ module ActiveFlag
 
       raise "active_flags on :#{column} already defined!" if active_flags[column]
 
-      self.active_flags[column] = Definition.new(column, keys, self)
+      self.active_flags[column] = Definition.new(column, keys.map(&:to_sym), self)
 
       # Getter
       define_method column do

--- a/lib/active_flag/definition.rb
+++ b/lib/active_flag/definition.rb
@@ -25,11 +25,11 @@ module ActiveFlag
     # http://stackoverflow.com/a/12928899/157384
 
     def set_all!(key)
-      @klass.update_all("#{@column} = COALESCE(#{@column}, 0) | #{@maps[key]}")
+      @klass.update_all("#{@column} = COALESCE(#{@column}, 0) | #{@maps[key.to_sym]}")
     end
 
     def unset_all!(key)
-      @klass.update_all("#{@column} = COALESCE(#{@column}, 0) & ~#{@maps[key]}")
+      @klass.update_all("#{@column} = COALESCE(#{@column}, 0) & ~#{@maps[key.to_sym]}")
     end
 
     def to_i(arg)

--- a/lib/active_flag/value.rb
+++ b/lib/active_flag/value.rb
@@ -22,11 +22,11 @@ module ActiveFlag
     end
 
     def set(key)
-      @instance.send "#{@column}=", add(key)
+      @instance.send "#{@column}=", add(key.to_sym)
     end
 
     def unset(key)
-      @instance.send "#{@column}=", delete(key)
+      @instance.send "#{@column}=", delete(key.to_sym)
     end
 
     def set!(key, options={})
@@ -40,11 +40,11 @@ module ActiveFlag
     end
 
     def set?(key)
-      include?(key)
+      include?(key.to_sym)
     end
 
     def unset?(key)
-      !set?(key)
+      !set?(key.to_sym)
     end
 
     def method_missing(symbol, *args, &block)

--- a/test/active_flag_test.rb
+++ b/test/active_flag_test.rb
@@ -15,12 +15,25 @@ class ActiveFlagTest < Minitest::Test
     assert @profile.languages.unset?(:chinese)
   end
 
+  def test_set_and_unset_strings?
+    assert @profile.features.set?(Features::EMAILS)
+    assert @profile.features.unset?(Features::STREAMING)
+  end
+
   def test_set_and_unset
     @profile.languages.set(:chinese)
     assert @profile.languages.chinese?
 
     @profile.languages.unset(:chinese)
     refute @profile.languages.chinese?
+  end
+
+  def test_set_and_unset_strings
+    @profile.features.set(Features::STREAMING)
+    assert @profile.features.set?(Features::STREAMING)
+
+    @profile.features.unset(Features::STREAMING)
+    refute @profile.features.set?(Features::STREAMING)
   end
 
   def test_set_and_unset!
@@ -35,6 +48,12 @@ class ActiveFlagTest < Minitest::Test
     @profile.languages = [:french, :japanese]
     assert @profile.languages.french?
     assert @profile.languages.japanese?
+  end
+
+  def test_string_assign
+    @profile.features = [Features::STREAMING, Features::AUTOMATION]
+    assert @profile.features.set?(Features::STREAMING)
+    assert @profile.features.set?(Features::AUTOMATION)
   end
 
   def test_direct_assign_nil
@@ -75,6 +94,9 @@ class ActiveFlagTest < Minitest::Test
 
     @profile.languages.set(:chinese)
     assert_equal @profile.languages.raw, 7
+
+    @profile.features.set(Features::AUTOMATION)
+    assert_equal @profile.features.raw, 5
   end
 
   def test_to_s
@@ -95,8 +117,14 @@ class ActiveFlagTest < Minitest::Test
     Profile.languages.set_all!(:chinese)
     assert Profile.first.languages.chinese?
 
+    Profile.features.set_all!(Features::STREAMING)
+    assert Profile.first.features.set?(Features::STREAMING)
+
     Profile.languages.unset_all!(:chinese)
     refute Profile.first.languages.chinese?
+
+    Profile.features.unset_all!(Features::STREAMING)
+    refute Profile.first.features.set?(Features::STREAMING)
   end
 
   def test_multiple_flags
@@ -127,5 +155,8 @@ class ActiveFlagTest < Minitest::Test
     assert_equal Profile.where_not_all_languages(:english, :japanese).count, 2
     assert_equal Profile.where_not_languages(:chinese).count, 3
     assert_equal Profile.where_not_all_languages(:chinese).count, 3
+    assert_equal Profile.where_features(Features::EMAILS, Features::STREAMING).count, 2
+    assert_equal Profile.where_features(Features::AUTOMATION).count, 0
+    assert_equal Profile.where_not_features(Features::AUTOMATION).count, 3
   end
 end

--- a/test/load_fixtures.rb
+++ b/test/load_fixtures.rb
@@ -6,13 +6,21 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:'
 
 ActiveRecord::Base.connection.create_table :profiles, force: true do |t|
   t.integer :languages, null: false, default: 0
+  t.integer :features, null: false, default: 0
   t.integer :figures
+end
+
+module Features
+  EMAILS = 'bronze.emails'
+  STREAMING = 'silver.streaming'
+  AUTOMATION = 'gold.automation'
 end
 
 class Profile < ActiveRecord::Base
   flag :languages, [:english, :spanish, :chinese, :french, :japanese]
   flag :others, [:thing]
   flag :figures, [:square, :circle]
+  flag :features, [Features::EMAILS, Features::STREAMING, Features::AUTOMATION]
 end
 
 class SubProfile < Profile
@@ -22,6 +30,6 @@ class Other < ActiveRecord::Base
   flag :others, [:another]
 end
 
-Profile.create(languages: [:english])
-Profile.create(languages: [:japanese])
+Profile.create(languages: [:english], features: [Features::EMAILS])
+Profile.create(languages: [:japanese], features: [Features::EMAILS, Features::STREAMING])
 Profile.create(languages: [:english, :japanese])


### PR DESCRIPTION
Hi @kenn thanks for awesome tool

We use it a lot and recently faced with a need to initialize a definition with string constants.
This might be a case when descriptors or keys are being used all over the app to perform some checks or modifications.
In my example, this is the list of made-up features:

```ruby
module Features
  EMAILS = 'bronze.emails'
  STREAMING = 'silver.streaming'
  AUTOMATION = 'gold.automation'
end

Profile.create(features: [Features::EMAILS, Features::STREAMING])
Profile.where_features(Features::EMAILS, Features::STREAMING)
```

so far this won't work since we're passing a string while [#to_i](https://github.com/kenn/active_flag/blob/master/lib/active_flag/definition.rb#L38) and set/unset/set?/unset? are expecting that `@maps` has symbols as the keys.

