### PR TITLE
Fix cause of ruby 3.4.0-rc1 frozen String deprecation warnings

### DIFF
--- a/lib/active_flag/value.rb
+++ b/lib/active_flag/value.rb
@@ -48,8 +48,8 @@ module ActiveFlag
     end
 
     def method_missing(symbol, *args, &block)
-      if key = symbol.to_s.chomp!('?') and @definition.keys.include?(key.to_sym)
-        set?(key.to_sym)
+      if key = symbol.to_s.chomp('?').to_sym and @definition.keys.include?(key)
+        set?(key)
       else
         super
       end


### PR DESCRIPTION
Appreciate your work on this gem :)

Currently, testing a project using this gem on ruby 3.4.0-rc1, or running this gem's test suite, displays the following deprecation warning:

    active_flag-2.0.2/lib/active_flag/value.rb:51: warning: warning: string returned by :something?.to_s will be frozen in the future

Where `:something?` is the method name being handled by `Value#method_missing`

This is a simple fix, to use `#chomp` instead of `#chomp!` to fix the behaviour in the warning, and make this gem one step closer to being compatible with Ruby 3.5 🎉 

Any issues let me know!